### PR TITLE
Simplify kubeconfig setup

### DIFF
--- a/config-kubectl.md
+++ b/config-kubectl.md
@@ -13,27 +13,20 @@ CA_PATH=path-from-the-previous-step
 ```
 kubectl config set-cluster ws-${USER} \
     --embed-certs=true \
-    --server=kubernetes \
+    --server=https://35.187.39.10 \
     --certificate-authority=${CA_PATH}
 kubectl config set-credentials ws-${USER} --token=${TOKEN}
 kubectl config set-context ws-${USER} \
     --cluster=ws-${USER} \
     --user=ws-${USER}
+    --namespace=${USER}
 kubectl config use-context ws-${USER}
 ```
-
-4. As we are going to make requests to https://kubernetes, we need to identify the real host for this hostname:
-
-```
-echo '35.187.39.10 kubernetes' | sudo tee -a /etc/hosts
-```
-
-(Please, don't forget to remove this line from `/etc/hosts` after the workshop)
 
 4. Check how it works:
 
 ```
-kubectl get pods -n ${USER}
+kubectl get pods
 ```
 
 As we haven't released anything yet, you will not see pods. But you shouldn't see any error either.


### PR DESCRIPTION
- IP address of the K8S cluster is added to the `kubeconfig` and not to `/etc/hosts`.
- `namespace` is added to the context, so end-users don't have to add `-n ${USER}` to every single command.